### PR TITLE
iOS6 dialog issue fixed (Safari)

### DIFF
--- a/src/sc/dialog.coffee
+++ b/src/sc/dialog.coffee
@@ -87,7 +87,7 @@ window.SC = SC.Helper.merge SC || {},
           if @options.window?
             @options.window.location = url
           else
-            @options.window = SC.Helper.openCenteredPopup url,
+            @options.window = SC.Helper.openCenteredPopup url.toString(),
               width: @WIDTH
               height: @HEIGHT
 

--- a/src/sc/dialog.coffee
+++ b/src/sc/dialog.coffee
@@ -37,6 +37,12 @@ window.SC = SC.Helper.merge SC || {},
           delete @_dialogs[dialogId]
 
     _handleInPopupContext: () ->
+      ###
+        window.opener is null due to this bug in chromium
+          http://code.google.com/p/chromium/issues/detail?id=136610
+        looks like none of the dialogs will function correctly in Chrome in iOS until
+        this is resolved
+      ###
       if @_getDialogIdFromWindow(window) && !window.location.pathname.match(/\/dialogs\//)
         isiOS5orGreater = (navigator.userAgent.match(/OS (\d)+(_\d)+ like Mac OS X/i))
         isiOS5orGreater = if isiOS5orGreater then parseInt(isiOS5orGreater[1]) >= 5 else false

--- a/src/sc/dialog.coffee
+++ b/src/sc/dialog.coffee
@@ -38,8 +38,9 @@ window.SC = SC.Helper.merge SC || {},
 
     _handleInPopupContext: () ->
       if @_getDialogIdFromWindow(window) && !window.location.pathname.match(/\/dialogs\//)
-        isiOS5 = (navigator.userAgent.match(/OS 5(_\d)+ like Mac OS X/i))
-        if isiOS5
+        isiOS5orGreater = (navigator.userAgent.match(/OS (\d)+(_\d)+ like Mac OS X/i))
+        isiOS5orGreater = if isiOS5orGreater then parseInt(isiOS5orGreater[1]) >= 5 else false
+        if isiOS5orGreater
           window.opener.SC.Dialog._handleDialogReturn(window)
         else if window.opener
           window.opener.setTimeout (->


### PR DESCRIPTION
Here's the original post reporting the issue: http://stackoverflow.com/questions/13537068/soundcloud-js-sdk-oauth-on-mobile. Here's a demo with the fix: https://dl.dropbox.com/u/9224326/www/scsdk/index.html

I don't have access to other phones for testing. Works on my iphone4 running iOS6.
 