### PR TITLE
Fix mixed-content warnings; always use client's protocol

### DIFF
--- a/src/sc/oembed.coffee
+++ b/src/sc/oembed.coffee
@@ -7,7 +7,7 @@ window.SC = SC.Helper.merge SC || {},
     query ||= {}
     query.url = trackUrl
 
-    uri = new SC.URI("http://" + SC.hostname() + "/oembed.json")
+    uri = new SC.URI(window.location.protocol + "//" + SC.hostname() + "/oembed.json")
     uri.query = query
 
     # rewrite callback if it's a DOM


### PR DESCRIPTION
@paulosman I believe this will fix this issue: https://jbuck.ca:4433/soundcloud.html.
