### PR TITLE
Fix sdk.js failing to load with Cannot read property 'TYPED_ARRAY_SUPPORT'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.js?$/,
-      exclude: /(node_modules)/,
+      exclude: /(node_modules|vendor)/,
       loader: 'babel-loader',
       query: {
         cacheDirectory: true


### PR DESCRIPTION
Fixes https://github.com/soundcloud/soundcloud-javascript/issues/55

Do not pass sources under vendor/ through Babel
Not only because it's unnecessary but vendor/audiomanager.js contains
code that is not strict mode compatible preventing Babel from parsing it
(it fails hard with syntax error).