### PR TITLE
Perform client-side redirect for /resolve

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -216,6 +216,14 @@ module.exports = {
    * @return {Promise}
    */
   resolve (url) {
-    return this.request('GET', '/resolve', { url: url });
+    return this.request('GET', '/resolve', {
+      url: url,
+      /*
+       * Tell the API not to serve a redirect. This is to get around
+       * CORS issues on Safari 7+, which likes to send pre-flight requests
+       * before following redirects, which has problems.
+       */
+      _status_code_map: { 302: 200 }
+    });
   }
 };

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -213,9 +213,10 @@ describe('API methods', function () {
     it('should resolve URLs properly', function(){
       var url = 'https://soundcloud.com/dj-perun/its-a-deep-bark';
       SC.resolve(url);
-      var requestUrl = this.requests[0].url;
-      var urlPart = decodeURIComponent(requestUrl.split('url=')[1]).split('&')[0];
+      var requestUrl = decodeURIComponent(this.requests[0].url);
+      var urlPart = requestUrl.split('url=')[1].split('&')[0];
       assert.ok(urlPart === url, 'The URL in the request should match the original URL');
+      assert.ok(requestUrl.indexOf('&_status_code_map[302]=200') >= 0, 'Should be mapping a 302 to a 200');
     });
   });
 });


### PR DESCRIPTION
This changes the behavior of resolving a permalink. Before, the
public-api would send a 302 redirect to the browser, which would then
follow that, eventually returning a 200 with a JSON payload of the
resource (if found.)

However, this was a problem for Safari 7+ (though I can't find a
documented bug for it.) Safari was not transparently following the
redirect on the simple CORS request. The reason is unclear; the origin
of the redirected-to host is the same as the original request host, and
it's a simple request (GET), with no additional headers that would
trigger the preflight[1]. As if to support that this is a bug, Chrome and
Firefox both do _not_ perform a preflight request before following the
redirect.

Since this is difficult to work around on the user agent itself, we'll
have to use an out provided by the api and map the 302 code to a 200.
We still get the redirect location in the JSON payload, so we can use
that (and in fact, we already had support for this.)

Performing the 'redirect' client-side causes the request to be made
using a simple CORS request, as it should be done.

Fixes #27 

[1]: https://www.w3.org/TR/cors/#cross-origin-request-with-preflight-0