### PR TITLE
Adjust the popup to be optimised for the new appearance

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -28,8 +28,8 @@ class Dialog {
     this.options = options;
     // will be used to identify the correct popup window
     this.options.state = this.id;
-    this.width = 456;
-    this.height = 510;
+    this.width = 420;
+    this.height = 670;
 
     this.deferred = deferred();
   }


### PR DESCRIPTION
Now that SoundCloud Connect has a new appearance, we should adjust the dialog size.

## Before

![screen shot 2017-01-16 at 13 38 29](https://cloud.githubusercontent.com/assets/364246/21983346/177d71f8-dbf1-11e6-81ba-9860a81e10f6.png)

## After

![screen shot 2017-01-16 at 13 37 00](https://cloud.githubusercontent.com/assets/364246/21983347/1780f42c-dbf1-11e6-9c9d-9f729fc01730.png)