### PR TITLE
Implementation of typings into sdk for Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.2",
   "description": "",
   "main": "sdk.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/soundcloud/soundcloud-javascript.git"

--- a/src/dialog/popup.js
+++ b/src/dialog/popup.js
@@ -10,6 +10,8 @@ module.exports = {
     const options = {};
     let stringOptions;
 
+    if (!window) return;
+
     options.location = 1;
     options.width = width;
     options.height = height;

--- a/src/player-api.js
+++ b/src/player-api.js
@@ -23,6 +23,7 @@ module.exports = function(scaudioPlayer) {
     let timerId = 0;
     let previousPosition = null;
     scaudioPlayer.onChange.subscribe(({ playing, seeking, dead }) => {
+      if (!window) return;
       if (dead) {
         window.clearTimeout(timerId);
       } else if (playing !== undefined || seeking !== undefined) {
@@ -30,6 +31,7 @@ module.exports = function(scaudioPlayer) {
       }
     });
     function doEmit() {
+      if (!window) return;
       window.clearTimeout(timerId);
       if (scaudioPlayer.isPlaying() && !scaudioPlayer.isEnded()) {
         timerId = window.setTimeout(doEmit, TIMEUPDATE_INTERVAL);

--- a/src/recorder/getusermedia.js
+++ b/src/recorder/getusermedia.js
@@ -1,6 +1,6 @@
-const getUserMedia = global.navigator.getUserMedia ||
+const getUserMedia = global.navigator ? (global.navigator.getUserMedia ||
                      global.navigator.webkitGetUserMedia ||
-                     global.navigator.mozGetUserMedia;
+                     global.navigator.mozGetUserMedia) : false;
 
 module.exports = (options, success, error) => {
   getUserMedia.call(global.navigator, options, success, error);

--- a/types/soundcloud/index.d.ts
+++ b/types/soundcloud/index.d.ts
@@ -1,0 +1,94 @@
+// Type definitions for soundcloud 3.3.2
+// Project: https://github.com/soundcloud/soundcloud-javascript
+// Definitions by: alrickemilien <https://github.com/soundcloud>
+
+/// <reference lib="dom"/>
+
+export default SC;
+
+declare namespace SC {
+    interface RecorderOptions {
+        source: string;
+        context?: AudioContext;
+    }
+
+    export class Recorder {
+        constructor(options: RecorderOptions);
+        delete(): void;
+        getBuffer(): Promise<AudioBuffer>;
+        getWAV(): Promise<Blob>;
+        play(): Promise<AudioBufferSourceNode>;
+        saveAs(filename: string): Promise<void>;
+        start(): Promise<AudioNode>;
+        stop(): void;
+    }
+
+    /**
+     * SCAudio.Player functions
+     */
+    export interface SCPlayer {
+        play: (...args: any[]) => any;
+        pause: (...args: any[]) => any;
+        seek: (...args: any[]) => any;
+        getVolume: (...args: any[]) => any;
+        setVolume: (...args: any[]) => any;
+        currentTime: (...args: any[]) => any;
+        getDuration: (...args: any[]) => any;
+        isBuffering: () => boolean;
+        isPlaying: () => boolean;
+        isActuallyPlaying: () => boolean;
+        isEnded: () => boolean;
+        isDead: () => boolean;
+        kill: (...args: any[]) => any;
+        hasErrored: () => boolean;
+        getState: () => "playing" | "ended" | "paused" | "dead" | "loading";
+    }
+
+    interface DialogOptions {
+        client_id: string,
+        redirect_uri: string,
+        response_type: string,
+        scope: string,
+        display: string,
+    }
+
+    interface SCOptions {
+        oauth_token?: string;
+        client_id?: string;
+        redirect_uri?: string;
+        baseURL?: string;
+        connectURL?: string;
+    }
+
+    export function connect(options?: {
+        client_id?: string,
+        redirect_uri?: string
+    }): Promise<DialogOptions>;
+    export function connectCallback(): void;
+    export function get(path: string, params: FormData | any): Promise<any>;
+    export function initialize(options: SCOptions): void;
+    export function isConnected(): boolean;
+
+    export function oEmbed(url: string, options?: {
+        element?: string,
+        scope?: string,
+        url?: string
+    }): Promise<DialogOptions>;
+
+    export function post(path: string, params: FormData | any): Promise<any>;
+    export function put(path: string, params: FormData | any): Promise<any>;
+
+    // delete is a keyword in typescript leading to this trick
+    function _delete(path: string, params: FormData | any): Promise<any>;
+    export { _delete as delete };
+
+    export function resolve(url: string): Promise<any>;
+    export function stream(trackPath: string, secretToken: string): Promise<SCPlayer>;
+    export function upload(options: {
+        title: string,
+        asset_data?: string,
+        file?: string,
+        progress?: (...args: any[]) => any,
+    }): Promise<any>;
+}
+

--- a/types/soundcloud/soundcloud-tests.ts
+++ b/types/soundcloud/soundcloud-tests.ts
@@ -1,0 +1,116 @@
+import SC from "soundcloud";
+
+/**
+ * SC.Recorder
+ */
+
+const rc: SC.Recorder = new SC.Recorder({
+    source: 'yayayaya',
+    context: new AudioContext(),
+});
+
+/**
+* API
+*/
+
+const scOpt = {
+    oauth_token: 'yayayaya',
+    client_id: 'yayayaya',
+    redirect_uri: 'yayayaya',
+    baseURL: 'yayayaya',
+    connectURL: 'yayayaya',
+};
+
+SC.initialize(scOpt);
+
+console.log('SC.isConnected() => ', SC.isConnected())
+
+SC.connect({
+    client_id: 'dudul',
+    redirect_uri: 'http://google.com',
+})
+    .then(() => {
+        try {
+            return SC.get('http://souncloud.com', scOpt);
+        } catch (error) {
+            console.error(error);
+            return Promise.resolve();
+        }
+    })
+    .then(() => {
+        try {
+            return SC.post('http://souncloud.com', scOpt);
+        } catch (error) {
+            console.error(error);
+            return Promise.resolve();
+        }
+    })
+    .then(() => {
+        try {
+            return SC.put('http://souncloud.com', scOpt);
+        } catch (error) {
+            console.error(error);
+            return Promise.resolve();
+        }
+    })
+    .then(() => {
+        try {
+            return SC.delete('http://souncloud.com', scOpt);
+        } catch (error) {
+            console.error(error);
+            return Promise.resolve();
+        }
+    })
+    .then(() => {
+        try {
+            return SC.resolve('http://souncloud.com');
+        } catch (error) {
+            console.error(error);
+            return Promise.resolve();
+        }
+    }).then(() => {
+        try {
+            return SC.oEmbed('http://souncloud.com', {
+                element: 'element',
+                scope: 'read',
+                url: 'http://souncloud.com'
+            });
+        } catch (error) {
+            console.error(error);
+            return Promise.resolve({});
+        }
+    }).then(() => {
+        try {
+            return SC.oEmbed('http://souncloud.com', {
+                element: 'element',
+                scope: 'read',
+                url: 'http://souncloud.com'
+            });
+        } catch (error) {
+            console.error(error);
+            return Promise.resolve({});
+        }
+    }).then(() => {
+        try {
+            return SC.stream('abcdefg', 'token');
+        } catch (error) {
+            console.error(error);
+            return Promise.resolve({});
+        }
+    }).then(() => {
+        try {
+            return SC.upload({
+                title: 'Upload title',
+                asset_data: 'data',
+                file: 'SomeFile.mp3',
+                progress: (p) => console.log('Progress: ' + p),
+            });
+        } catch (error) {
+            console.error(error);
+            return Promise.resolve();
+        }
+    });
+
+
+
+

--- a/types/soundcloud/tsconfig.json
+++ b/types/soundcloud/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "soundcloud-tests.ts"
+    ]
+}

--- a/types/soundcloud/tslint.json
+++ b/types/soundcloud/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Trying to answer to  #69

Implementation may not be as usual, it's nested into the repo and referenced by the `package.json`.

Other packages implement typings at [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).

The file `index.d.ts` into the folder `types/soundcloud` should be available at base directory of the npm package, next to `sdk.js`.